### PR TITLE
Fix the navbar icons in the mobile view alignments are left aligned problem

### DIFF
--- a/assets/css/custom_css.css
+++ b/assets/css/custom_css.css
@@ -57,10 +57,13 @@
   
   .search-icon {
     display: none;
+    margin-right: 4.0rem;
   }
   
   .phone-icon {
     display: none;
+    margin-right: 4.2rem;
+    margin-left: 2.0rem;
   }
   
   .mobile-view{


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix  #60 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Fixing the navbar icons in the mobile view alignments are left aligned problem

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
I fixed the navbar icons in the mobile view alignments are left aligned problem

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->

Can't get screenshots as there is a problem
  
### Preview Link

https://yoshitharathnayake.github.io/sack-blog/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
